### PR TITLE
i is a variable not a constant

### DIFF
--- a/countdown.php
+++ b/countdown.php
@@ -167,7 +167,7 @@ class CountdownTimer
     for ($i = 0; $i < $strlen; $i++) {
       $dimensions = imagettfbbox($size, $angle, $fontfile, $string[$i]);
       $this->fontSettings['characterWidths'][] = array(
-        $string[i] => $dimensions[2]
+        $string[$i] => $dimensions[2]
       );
     }
 


### PR DESCRIPTION
Fix of a typo and prevention of `Warning: Use of undefined constant i - assumed 'i' (this will throw an Error in a future version of PHP)`. 

